### PR TITLE
Adjust to changes in elmer: 

### DIFF
--- a/R/GitAI.R
+++ b/R/GitAI.R
@@ -23,8 +23,8 @@ GitAI <- R6::R6Class(
       if (is.null(private$.llm))
         stop(call. = FALSE, "LLM not set. Use set_llm() first.")
 
-      if (missing(value)) return(private$.llm$system_prompt)
-      private$.llm$system_prompt <- value
+      if (missing(value)) return(private$.llm$get_system_prompt())
+      private$.llm$set_system_prompt(value)
     },
 
     gitstats = function(value) {

--- a/tests/testthat/test-set_llm.R
+++ b/tests/testthat/test-set_llm.R
@@ -2,8 +2,8 @@ test_that("setting LLM ", {
 
   my_project <- initialize_project("gitai_test_project")
 
-  my_project <- 
-    my_project |> 
+  my_project <-
+    my_project |>
     set_llm()
 
   expect_true("Chat" %in% class(my_project$llm))
@@ -15,18 +15,18 @@ test_that("setting system prompt", {
   my_project <- initialize_project("gitai_test_project")
 
   expect_error(
-    my_project |> 
+    my_project |>
     set_prompt(system_prompt = "You always return only 'Hi there!'")
   )
 
-  my_project <- 
-    my_project |> 
-    set_llm() |> 
+  my_project <-
+    my_project |>
+    set_llm() |>
     set_prompt(system_prompt = "You always return only 'Hi there!'")
 
   expect_equal(
-    my_project$llm$system_prompt, "You always return only 'Hi there!'") 
-  
+    my_project$llm$get_system_prompt(), "You always return only 'Hi there!'")
+
   expect_equal(
     my_project$llm$chat("Hi"),
     "Hi there!"


### PR DESCRIPTION
use `set_system_prompt()` and `get_system_prompt()` instead of `system_prompt` active field.