### PR TITLE
fix: Prepare for upcoming ellmer v0.4.0 release

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -54,7 +54,7 @@ chat_openai_mocked <- function(system_prompt = NULL,
     model = model,
     params = params,
     extra_args = api_args,
-    api_key = api_key,
+    credentials = function() api_key,
     provider_class = ellmer:::ProviderOpenAI
   )
 }

--- a/tests/testthat/test-set_llm.R
+++ b/tests/testthat/test-set_llm.R
@@ -60,7 +60,7 @@ test_that("setting arguments for selected provider ", {
   my_project <- my_project |>
     set_llm(provider = "openai", model = "model_mocked")
   expect_equal(
-    my_project$llm$.__enclos_env__$private$provider@model,
+    my_project$llm$get_provider()@model,
     "model_mocked"
   )
 
@@ -68,7 +68,7 @@ test_that("setting arguments for selected provider ", {
   my_project <- my_project |>
     set_llm(provider = "openai", api_key = "api_key_mocked")
   expect_equal(
-    my_project$llm$.__enclos_env__$private$provider@api_key,
+    my_project$llm$get_provider()@credentials(),
     "api_key_mocked"
   )
 
@@ -76,6 +76,7 @@ test_that("setting arguments for selected provider ", {
   my_project <- my_project |>
     set_llm(provider = "openai", echo = "all")
   expect_equal(
+    # Please don't reach into the private namespace of external R6 classes
     my_project$llm$.__enclos_env__$private$echo,
     "all"
   )


### PR DESCRIPTION
Hi there! We're preparing for the next ellmer release (v0.4.0) and reverse dependency checks turned up a couple of issues with the new release in GitAI.

The biggest change I was able to find and fix is the move from using an `api_key` argument in favor of the new `credentials` argument. (Discussed in https://github.com/tidyverse/ellmer/issues/613, implemented in  https://github.com/tidyverse/ellmer/pull/799.) `credentials` is by default a zero-argument function that returns the API key as a string.

I updated `chat_openai_mocked()` to take `api_key` as currently but to wrap it into the kind of function expected by `credentials`.

If your tests uncover other impacts from the new ellmer v0.4.0 release candidate, I'll be happy to help you update GitAI as needed.

---

Relatedly, while in this same area, I noticed that in a few places you're reacing into the private methods of the `Chat` class, or using internal functions from the ellmer package.

I fixed two of these instances, but I strongly urge you to take a pass through your tests and to avoid reaching into ellmer's private namespace or private methods in ellmer's classes. 

Typically, there are public methods that you can use for your testing, but we also welcome feedback in https://github.com/tidyverse/ellmer and would happily field requests to make useful methods public.

When you write tests around private methods and functions, you risk your package tests failing when we make updates, which in turn can delay updates and new releases and can increase the risk that your package might be removed from CRAN due to internal changes in another package.